### PR TITLE
add constraint for op functions: ONLY Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,6 @@
 
 * 6/12/2021 Layout implementation of an idea
 * 2/01/2022 Initial release
+
+#### 1.0.0
+* 7/01/2022 op now support only lambda functions with not body block and not arguments

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # JS-Like-Numbers
-Currently Supported for **ES6** and **higher**
+Supported for **ES6** and **higher**
 
 **A small, fast JavaScript library for arbitrary-precision decimal arithmetic in javascript notation.**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-like-numbers",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A small, fast JavaScript library for arbitrary-precision decimal arithmetic in javascript notation.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,23 +4,20 @@ import { BinaryOperator, UnaryOperator } from "./enum"
 import { parseScript } from 'esprima'
 
 function getReturnStatementAst(func: TFunction) {
-    const funcStr = `(${String(func)})`
-    const { body: [ast] } = parseScript(funcStr)
-    let funcAst: any
-    switch (ast.type) {
-        case 'ExpressionStatement':
-            funcAst = ast.expression;
-            break
-        case 'FunctionDeclaration':
-            funcAst = ast;
-    }
+  const funcStr = `(${String(func)})`
+  const { body: [ast] } = parseScript(funcStr)
+  const expression = (ast as any).expression
 
-    if (funcAst.body.type === 'BlockStatement') {
-        const { body: funcBodyAst } = funcAst.body
-        const returnSTatementAst = funcBodyAst.find((statement: any) => statement.type === 'ReturnStatement')
-        return returnSTatementAst.argument
-    }
-    return funcAst.body
+  const isArrowFunction = ast.type === 'ExpressionStatement' && ast.expression.type === 'ArrowFunctionExpression'
+  if (!isArrowFunction) throw new Error('Provided function MUST be Lambda function without body block.')
+
+  const hasBodyBlock = expression.body.type === 'BlockStatement'
+  if (hasBodyBlock) throw new Error('Provided function MUST be Lambda function without body block.')
+
+  const hasArguments = expression.params.length
+  if(hasArguments)throw new Error('Provided function arguments list MUST be empty.')
+
+  return expression.body
 }
 
 function performMath(unaryOperator: UnaryOperator, operand: string | Big): Big


### PR DESCRIPTION
Starting from v2 only lambda functions with no body block and with no arguments will be allowed.